### PR TITLE
Updating color palette of dots.

### DIFF
--- a/GameTest/src/Dot.java
+++ b/GameTest/src/Dot.java
@@ -7,7 +7,7 @@ public class Dot {
 	
 	public int x;
 	public int y;
-	
+	private int p, w, v;
 	private int r, g, b;
 	public double mass;
 	
@@ -31,12 +31,14 @@ public class Dot {
 
 	private boolean isRGBNotWhite() {
 		Random rand = new Random();
-
+		p = r - g;
+		w = g - b;
+		v = b - r;
 		r = rand.nextInt(255);
 		g = rand.nextInt(255);
 		b = rand.nextInt(255);
 		
-		while(r > 220 && g > 220 && b > 220) {
+		while(p > 80 || w > 80 || v > 80 || r > 220 && g > 220 && b > 220 || r < 50 && g < 50 && b < 50) {
 			r = rand.nextInt(255);
 			g = rand.nextInt(255);
 			b = rand.nextInt(255);


### PR DESCRIPTION
I did a little testing with the RGB palette and noticed that the closer the values are in relative to each other the closer the color is to a grayscale palette(EX. R = 140, G = 140, B = 140; R = 24 G = 24, B = 24, etc. So to avoid that, I added new integers "p,w,v" that represent the difference between the RGB values to vary by at least 80. These "p,w,v" values are then inputted into the while parameter. Example: if R was at a value of 200, the green and blue value being outputted cannot be anything over 120, and if otherwise the values will be "re-rolled" at another value until the parameters are met.

Additionally, addressing the dot.isRGBNotWhite's parameters, since the greater the RGB values are the darker it is, these parameters are to avoid darker colors? I personally like that as an extra precaution to get rid of the grayscale colors in the darker area to avoid a "near-black" color. So in addition to parameters values of over 220, perhaps we can also add parameters that are less than something like 50 (or a smaller value) as they represent more of the "lighter" palette? 

If we go through those changes of both not white, nor black, or a grayscale color in that matter LOL. Maybe we can rename the boolean function to like "isRGBNotGrayscale" or something like that.